### PR TITLE
git_modules includes submodule version and branch if present.

### DIFF
--- a/spec/license_auto/package_manager/git_module_spec.rb
+++ b/spec/license_auto/package_manager/git_module_spec.rb
@@ -2,10 +2,19 @@ require 'spec_helper'
 require 'license_auto/package_manager/git_module'
 
 describe LicenseAuto::GitModule do
-  let(:repo_dir) { test_case_dir(nil)}
+
+  let(:repo_dir) { test_case_dir(".")}
+
   let(:target_modules) {
-    [{:dep_file=>"spec/fixtures/github.com/mineworks/license_auto_test_case/.gitmodules",
-      :deps=>[{:name=>"https://github.com/github/ohnogit", :version=>nil, :remote=>"https://github.com/github/ohnogit"}]}]
+    [{:dep_file=>"spec/fixtures/github.com/mineworks/license_auto_test_case/./.gitmodules",
+      :deps=>[{
+                  :name=>"deps/ohnogit",
+                  :path=>"deps/ohnogit",
+                  :url=>"https://github.com/github/ohnogit.git",
+                  :version=>"ce052f4d0cd3f33759dd6f7fd12f5e24bde84309",
+                  #:branch=>nil,
+                  :remote=>"https://github.com/github/ohnogit"
+              }]}]
   }
 
   let(:pm) {LicenseAuto::GitModule.new(repo_dir)}


### PR DESCRIPTION
This changes the format of the hash returned from parse_dependencies.
1. Changed name from url to actual submodule name from .gitmodules
2. Added all name/value pairs from .gitmodules (i.e. adds branch if
present)
3. Added :version based on output from `git submodule status`

These changes may need to be adjusted to not break code that's expecting the
current response format.
